### PR TITLE
Fix link preload type

### DIFF
--- a/src/pages/thoughts/react-svg-sprites.md
+++ b/src/pages/thoughts/react-svg-sprites.md
@@ -132,7 +132,7 @@ To preload the sprite, you add a link tag to the head of the document.
 
 ```html
 <head>
-  <link rel="preload" as="image/svg+xml" href="sprite.svg">
+  <link rel="preload" href="sprite.svg" as="image" type="image/svg+xml">
 </head>
 ```
 Depending on your server's configuration, you might need to make sure the proper cache-headers are set on your sprite.svg so the browser can cache it appropriately. 


### PR DESCRIPTION
Correct `as` attribute value is `image`, `image/svg+xml` can be set as a `type` attribute value 🙌

Chrome warning:

<img width="436" alt="image" src="https://github.com/benadam11/personal-site-v4/assets/6711845/d0e27843-1b2e-4386-9725-a74439e8f0b8">

[MDN list of types](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload#what_types_of_content_can_be_preloaded)